### PR TITLE
use host as address

### DIFF
--- a/remy/gui/app.py
+++ b/remy/gui/app.py
@@ -301,6 +301,11 @@ class RemyInitWorker(QRunnable):
 
   def run(self):
     args = self.args
+
+    # host should be assumed to be the address (unless specified otherwise)
+    if "host" in args and not "address" in args:
+      args["address"] = args["host"]
+
     app = QApplication.instance()
     fsource = None
     try:


### PR DESCRIPTION
Recent updates introduced the asynchronous loading (and cool new icons and screens, yay) but they also broke the configuration in from the readme.
Where we used the terminology from ssh and rsync and called the address "host".
In the connect function this currently leads to ignoring the configuration and instead falling back to the default address.
This is the dirty fix, that should ensure nothing breaks.
I think a cleaner solution would be to decide whether the option should be called "host" or "address" and change the connect function or the configuration parts accordingly.