### PR TITLE
Make cache_dir a required param when initializing LiveFileSourceSSH

### DIFF
--- a/remy/remarkable/filesource.py
+++ b/remy/remarkable/filesource.py
@@ -178,7 +178,7 @@ class LiveFileSourceSSH(FileSource):
 
   _dirty = False
 
-  def __init__(self, ssh, name="SSH", cache_dir=None, username=None, remote_documents=None, remote_templates=None, use_banner=False, connect=True, utils_path='$HOME', **kw):
+  def __init__(self, ssh, cache_dir, name="SSH", username=None, remote_documents=None, remote_templates=None, use_banner=False, connect=True, utils_path='$HOME', **kw):
     self.ssh = ssh
     self.name = name
 


### PR DESCRIPTION
`cache_dir=None` seems to imply that `cache_dir` can be omitted, or that the default value of `None` will mean no cache dir is used. 

But actually the class fails to initialize because line 185 expects `cache_dir` to be non-null. 

This change requires `cache_dir` to be specified so that the class does not fail to initialize during runtime.