### PR TITLE
rm path error

### DIFF
--- a/remy/remarkable/filesource.py
+++ b/remy/remarkable/filesource.py
@@ -6,7 +6,7 @@ import json
 from stat import S_ISREG, S_ISDIR
 import subprocess
 from shutil import which
-
+from pathlib import PurePosixPath
 from threading import RLock
 
 from remy.utils import log
@@ -254,7 +254,7 @@ class LiveFileSourceSSH(FileSource):
     return path.join(self.local_roots[branch], *paths)
 
   def _remote(self, *paths, branch=DOCSDIR):
-    return path.join(self.remote_roots[branch], *paths)
+    return str(PurePosixPath(self.remote_roots[branch]).joinpath(*paths))
 
   def isReadOnly(self):
     return False


### PR DESCRIPTION
I found the problem in #36 . Function _remote should return a POSIX path but it actually returns a windows path. I use pathlib.PurePosixPath to address this issue. 