### PR TITLE
Feature/custom launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Obviously, this source is read-only: you cannot upload PDFs to it.
   "timeout": 3,
   "persist_cache": true,
   "use_banner": "remy-banner.png"
+  "launchers": ["xochitl", "remux", "tarnish", "draft"],
+  "enable_webui_export": false
 }
 ```
 
@@ -161,6 +163,15 @@ The cache is kept across runs, and files are re-downloaded if modified date or s
 This might leave behind some files and might miss some updates.
 By setting `persist_cache` to `true` the cache is cleared every time.
 
+The `enable_webui_export` determines if Remy should include the option of using the WebUI of the reMarkable to generate exports of documents.
+This is only available if the launcher is `xochitl` and `use_banner` is false.
+
+The `launchers` option is a list of launchers that you want supported.
+Remy will detect which one is currently active using `systemctl`.
+This is useful when rebooting the launcher to ensure that the changes are picked up on the tablet.
+By default, Remy looks for `xochitl`, `remux`, `tarnish`, and `draft`.
+
+
 #### Rsync source
 
 ```json
@@ -175,7 +186,9 @@ By setting `persist_cache` to `true` the cache is cleared every time.
   "use_banner": "remy-banner.png",
   "cache_mode": "on_demand",
   "rsync_path": "/path/to/local/rsync",
-  "rsync_options": [ "--rsync-path=/opt/bin/rsync" ]
+  "rsync_options": [ "--rsync-path=/opt/bin/rsync" ],
+  "launchers": ["xochitl", "remux", "tarnish", "draft"],
+  "enable_webui_export": false
 }
 ```
 

--- a/remy/remarkable/config.py
+++ b/remy/remarkable/config.py
@@ -56,6 +56,8 @@ OPTIONS_DEFAULTS = {
 }
 
 
+LAUNCHERS = ["xochitl", "remux", "tarnish", "draft"]
+
 SOURCE_DEFAULTS = {
   "name": "reMarkable",
   "hidden": False,
@@ -64,6 +66,7 @@ SOURCE_DEFAULTS = {
   "username": "root",
   "host_key_policy": "ask",
   "timeout": 3,
+  "launchers": LAUNCHERS,
   "use_banner": False,
   "enable_webui_export": False
 }

--- a/remy/remarkable/filesource.py
+++ b/remy/remarkable/filesource.py
@@ -10,6 +10,7 @@ from pathlib import PurePosixPath
 from threading import RLock
 
 from remy.utils import log
+from remy.remarkable.config import LAUNCHERS
 
 
 
@@ -181,7 +182,7 @@ class LiveFileSourceSSH(FileSource):
 
   _dirty = False
 
-  def __init__(self, ssh, id='', name="SSH", cache_dir=None, username=None, remote_documents=None, remote_templates=None, use_banner=False, connect=True, utils_path='$HOME', persist_cache=True, launchers=["xochitl"], **kw):
+  def __init__(self, ssh, id='', name="SSH", cache_dir=None, username=None, remote_documents=None, remote_templates=None, use_banner=False, connect=True, utils_path='$HOME', persist_cache=True, launchers=LAUNCHERS, **kw):
     self.ssh = ssh
     self.name = name
     self.persist_cache = persist_cache
@@ -196,7 +197,7 @@ class LiveFileSourceSSH(FileSource):
       shutil.rmtree(cache_dir, ignore_errors=True)
     self._makeLocalPaths()
 
-    log.info("Supported launchers: %s", ', '.join(launchers))
+    log.debug("Supported launchers: " + ', '.join(launchers))
     for launcher in launchers:
       _,out,_ = self.ssh.exec_command(f"systemctl is-active {launcher}")
       if out.channel.recv_exit_status() == 0:
@@ -435,7 +436,7 @@ class LiveFileSourceRsync(LiveFileSourceSSH):
   def __init__(self, ssh, data_dir, name="Rsync",
                username="root", host="10.11.99.1", key=None,
                rsync_path=None, rsync_options=None, remote_documents=None, remote_templates=None,
-               use_banner=False, cache_mode="on_demand", known_hosts=None, host_key_policy="ask", launchers=["xochitl"], **kw):
+               use_banner=False, cache_mode="on_demand", known_hosts=None, host_key_policy="ask", launchers=LAUNCHERS, **kw):
     LiveFileSourceSSH.__init__(self, ssh, name=name, cache_dir=data_dir,
                                remote_documents=remote_documents, remote_templates=remote_templates,
                                use_banner=use_banner, connect=False, launchers=launchers)

--- a/remy/remarkable/filesource.py
+++ b/remy/remarkable/filesource.py
@@ -212,10 +212,14 @@ class LiveFileSourceSSH(FileSource):
     if remote_templates:
       self.remote_roots[1] = remote_templates
 
-    if use_banner and self._launcher:
+    if use_banner:
       self._dirty = True # force restart of launcher even when stopping failed
-      _,out,_ = ssh.exec_command(f"/bin/systemctl stop {self._launcher}")
-      if out.channel.recv_exit_status() == 0:
+      if self._launcher:
+        _,out,_ = ssh.exec_command(f"/bin/systemctl stop {self._launcher}")
+        launcher_stopped = out.channel.recv_exit_status() == 0
+      else:
+        launcher_stopped = True
+      if launcher_stopped:
         _,out,_ = ssh.exec_command(utils_path + "/remarkable-splash '%s'" % use_banner)
         out.channel.recv_exit_status()
       else:


### PR DESCRIPTION
A solution to #50.
New setting in source config:

    "launchers": ["launcher1", "launcher2"]

Remy will go through the list of launchers and the first active one will be stopped/restarted as needed.
The default is `["xochitl"]`.
A better default might include remux, tarnish, draft.